### PR TITLE
fix post-install on linux without coffee-script installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "(set NODE_ENV=test) & mocha --compilers coffee:coffee-script -R spec",
-    "postinstall": "coffee --bare -o lib -c src"
+    "postinstall": "PATH=$PATH:./node_modules/.bin coffee --bare -o lib -c src"
   },
   "dependencies": {
     "async": "0.1.22",


### PR DESCRIPTION
Hi,

I don't want coffee-script to be globally installed on my computer.

To make post-install scripts pass, I override the PATH to include `node_modules/.bin` directory. Tested on linux. I have no idea if it works on Windows...

Cheers
Romain
