### PR TITLE
global option(-g) should be removed from the preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "test": "NODE_ENV=test mocha --compilers coffee:coffee-script -R spec",
     "test-win": "(set NODE_ENV=test) & mocha --compilers coffee:coffee-script -R spec",
-    "preinstall": "npm install -g coffee-script mocha",
+    "preinstall": "npm install coffee-script mocha",
     "postinstall": "coffee --bare -o lib -c src"
   },
   "dependencies": {


### PR DESCRIPTION
Because of the global option (-g), users need to use sudo to execute `npm install`.
Probably most users prefer to it.

Thanks.
Kohei Kawasaki
