### PR TITLE
Swagger-jack might interfere with connect.json 

### DIFF
--- a/src/validator.coffee
+++ b/src/validator.coffee
@@ -260,17 +260,14 @@ validate = (req, path, specs, next) ->
     )
 
   return process() if req.is('json') or req.is('application/x-www-form-urlencoded') or req.is('multipart/form-data')
-  # body parsing, if incoming request is not json, multipart or form-urlencoded
-  # by default, no body
-  delete req.body
-  # TODO, set request encoding to the incoming charset or to utf8 by default
-  req.on('data', (chunk) ->
-    if(!req.body)
-      req.body = ''
-    req.body += chunk
-  )
-
-  # only process raw body at the end.
+  
+  # body parsing should be done by connect.json(), connect.bodyParser() or any other body parser!
+  
+  # if connect.json() has already defined the body, that means end has been triggered so just process
+  # this might occured when content-size is 0!
+  return process() if req.body
+  # else wait the end and process
+  # body might be processed or not, this is not part of swagger-jack job
   return req.on('end', process)
 
 # Validator function.


### PR DESCRIPTION
imho, swagger-jack should not process body. More over, this can cause error as the body was not converted to json. Is users needs body parsing, it should be done by specific parsers like connect.bodyParser() or connect.json().
Swagger-jack is tolerant with missing body and will handle it like any body attribute is undefined.
