### PR TITLE
Missing models in resource API

### DIFF
--- a/test/apiGeneration.coffee
+++ b/test/apiGeneration.coffee
@@ -456,6 +456,7 @@ describe 'API generation tests', ->
                 httpMethod: 'GET'
               ]
             ],
+            models: {},
             resourcePath: '/source'
           server.close()
           done()
@@ -682,4 +683,5 @@ describe 'API generation tests', ->
                 nickname: 'remove'
               ]
             ]
+            models: {}
           done()

--- a/test/apiGeneration.coffee
+++ b/test/apiGeneration.coffee
@@ -476,10 +476,13 @@ describe 'API generation tests', ->
         .use(swagger.generator(app, 
           apiVersion: '1.0',
           basePath: root
-        , [
+        , [{
+          api: require './fixtures/addressApi.yml'
+          controller: passed: (req, res) -> res.json status: 'passed'
+        },{
           api: require './fixtures/complexApi.yml'
           controller: passed: (req, res) -> res.json status: 'passed'
-        ]))
+        }]))
         # use validator also because it manipulates models
         .use(swagger.validator(app))
       server = http.createServer app
@@ -492,7 +495,7 @@ describe 'API generation tests', ->
     it 'should reference models be untouched', (done) ->
       # when requesting the API description details
       request.get
-        url: 'http://'+host+':'+port+'/api-docs.json/example'
+        url: 'http://'+host+':'+port+'/api-docs.json/address'
         json: true
       , (err, res, body) ->
         return done err if err?
@@ -501,14 +504,14 @@ describe 'API generation tests', ->
         assert.deepEqual body,
           apiVersion: '1.0'
           basePath: '/api'
-          resourcePath: '/example'
+          resourcePath: '/address'
           apis: [
-            path: '/example'
+            path: '/address'
             operations: [
               httpMethod: 'POST'
               nickname: 'passed'
               parameters: [
-                dataType: 'User'
+                dataType: 'Address'
                 paramType: 'body'
                 required: true
               ]
@@ -525,18 +528,11 @@ describe 'API generation tests', ->
                 city:
                   type: 'string'
 
-            User:
-              id: 'User'
+            SomethingElse:
+              id: 'SomethingElse'
               properties:
-                id:
-                  type: 'int'
-                  required: true
                 name:
                   type: 'string'
-                addresses:
-                  type: 'array'
-                  items: 
-                    $ref: 'Address'
         done()
 
   describe 'given a properly configured and started server', ->

--- a/test/fixtures/addressApi.yml
+++ b/test/fixtures/addressApi.yml
@@ -1,0 +1,31 @@
+resourcePath: /address
+apis: 
+
+- path: /address
+  operations:
+
+  - httpMethod: POST
+    nickname: passed
+    parameters:
+
+    - dataType: Address
+      paramType: body
+      required: true
+
+models:
+
+  Address:
+    id: Address
+    properties:
+      zipcode:
+        type: long
+      street:
+        type: string
+      city:
+        type: string
+
+  SomethingElse:
+    id: SomethingElse
+    properties:
+      name:
+        type: string

--- a/test/fixtures/complexApi.yml
+++ b/test/fixtures/complexApi.yml
@@ -6,6 +6,7 @@ apis:
 
   - httpMethod: POST
     nickname: passed
+    responseClass: SomethingElse
     parameters:
 
     - dataType: User
@@ -13,16 +14,6 @@ apis:
       required: true
 
 models:
-
-  Address:
-    id: Address
-    properties:
-      zipcode:
-        type: long
-      street:
-        type: string
-      city:
-        type: string
 
   User:
     id: User


### PR DESCRIPTION
Models can't be defined twice in different resources, but it implies that models are missing in one resource.

This PR fix that.
