### PR TITLE
Better mandatory values check

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/feugy/swagger-jack"
   },
   "license": "MIT",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "main": "lib/index.js",
   "engines": {
     "node": "+0.8.0"

--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -139,7 +139,7 @@ addRoutes = (descriptor, resources) ->
 
           # make sure the responseClass model is defined
           if operation.responseClass
-            if operation.responseClass != "void"
+            if operation.responseClass isnt "void"
               resource.api.models[operation.responseClass] or= descriptor.models[operation.responseClass]
               unless resource.api.models[operation.responseClass]?
                 throw new Error("responseClass #{operation.responseClass} doesn't match a model")
@@ -230,7 +230,7 @@ module.exports = (app, descriptor, resources, options = {}) ->
    catch err
      err2 = new Error("Failed to create routes from resources: #{err.toString()}")
      err2.stack = err.stack
-     throw err2;
+     throw err2
 
   # Express middleware for serving the descRoute.
   return (req, res, next) ->

--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -29,14 +29,14 @@ validateParameters = (parameters, models, path, method) ->
 
   if duplicates.length > 0
     throw new Error("#{errorPrefix} has duplicates parameters: #{duplicates.join(',')}")
-  
+
   # validates path parameter names and number
   pathParameters = _.filter(parameters, (p) -> return p?.paramType?.toLowerCase() is 'path')
   [__, routeParameters] = utils.extractParameters(utils.pathToRoute(path))
   routeParametersLength = _.keys(routeParameters).length
   if routeParametersLength isnt pathParameters.length
     throw new Error("#{errorPrefix} declares #{routeParametersLength} parameters in its path, and #{pathParameters.length} in its parameters array - you missed something")
-  for name of routeParameters 
+  for name of routeParameters
     unless _.find(pathParameters, (p) -> return p.name is name)?
       throw new Error("#{errorPrefix} declares parameter #{name} in its path, but not in its parameters array - propably a typo")
 
@@ -78,7 +78,7 @@ validateParameters = (parameters, models, path, method) ->
 validateModel = (model, id, models) ->
   # checks that model has an id
   if model.id isnt id
-    throw new Error("model #{id} not declared with the same id") 
+    throw new Error("model #{id} not declared with the same id")
   unless !_.isEmpty(model.properties) or model.additionalProperties or !_.isEmpty(model.items)
     throw new Error("model #{id} does not declares properties")
   if models[id]?
@@ -122,26 +122,29 @@ addRoutes = (descriptor, resources) ->
       # analyze each api within a given resource
       for api in resource.api.apis
         unless _.isString(api.path)
-          throw new Error("Resource #{resource.api.resourcePath} has an api without path - D\'oh'") 
-        
+          throw new Error("Resource #{resource.api.resourcePath} has an api without path - D\'oh'")
+
         continue unless _.isArray api.operations
         for operation in api.operations
           # check mandatory informations
           unless _.isString(operation.httpMethod)
             throw new Error("Api #{api.path} has an operation without http method - what is the police doing ?")
-          
+
           verb = operation.httpMethod.toLowerCase()
           unless verb in ['get', 'post', 'delete', 'put', 'options', 'head']
-            throw new Error("Api #{api.path} operation #{operation.httpMethod} is not supported - I\'m so sorry Janice") 
-            
+            throw new Error("Api #{api.path} operation #{operation.httpMethod} is not supported - I\'m so sorry Janice")
+
           unless _.isString(operation.nickname)
             throw new Error("Api #{api.path} operation #{operation.httpMethod} does not specify a nickname - we cannot guess the corresponding controller method")
-          
+
           # make sure the responseClass model is defined
           if operation.responseClass
-            resource.api.models[operation.responseClass] or= descriptor.models[operation.responseClass]
-            unless resource.api.models[operation.responseClass]?
-              throw new Error("responseClass #{operation.responseClass} doesn't match a model")
+            if operation.responseClass != "void"
+              resource.api.models[operation.responseClass] or= descriptor.models[operation.responseClass]
+              unless resource.api.models[operation.responseClass]?
+                throw new Error("responseClass #{operation.responseClass} doesn't match a model")
+          else
+            throw new Error("responseClass is mandatory. If no result expected, responseClass should be void")
 
           # Validates parameters
           if _.isArray(operation.parameters)
@@ -152,11 +155,11 @@ addRoutes = (descriptor, resources) ->
             for parameter in operation.parameters
               if parameter.dataType
                 resource.api.models[parameter.dataType] or= descriptor.models[parameter.dataType]
-          
+
           route = utils.pathToRoute(api.path)
           unless operation.nickname of resource.controller
             throw new Error("Api #{api.path} nickname #{operation.nickname} cannot be found in controller")
-          
+
           # load the relevant script that must contain the middelware
           routes.push({method:verb, path:route, middleware: resource.controller[operation.nickname]})
           if /swagger/.test process.env?.NODE_DEBUG
@@ -164,7 +167,7 @@ addRoutes = (descriptor, resources) ->
 
     # enrich descriptor
     descriptor.apis.push(resource.api)
-  
+
   return routes
 
 # Generator function.
@@ -176,7 +179,7 @@ addRoutes = (descriptor, resources) ->
 #   "apiVersion":"0.2",
 #   "basePath":"http:#mydomain.com/api"
 #
-# The following array contains descriptor and code for each resource. 
+# The following array contains descriptor and code for each resource.
 # A resource descriptor is analyzed and the corresponding routes are registered within the specified Express application.
 #
 # @param app [Object] the enriched Express application.
@@ -191,17 +194,17 @@ module.exports = (app, descriptor, resources, options = {}) ->
   # validates inputs
   unless app?.handle? and app?.set?
     throw new Error('No Express application provided')
-  
+
   unless _.isObject(descriptor)
     throw new Error('Provided root descriptor is not an object')
-  
+
   unless _.isArray(resources)
     throw new Error('Provided resources must be an array')
 
   options.descPath or= '/api-docs.json'
 
   descRoute = new RegExp("#{options.descPath}(/.*)?")
-  
+
   try
     # enrich the descriptor with apis
     routes = addRoutes(descriptor, resources)
@@ -211,7 +214,7 @@ module.exports = (app, descriptor, resources, options = {}) ->
       for route in routes
         app[route.method](route.path, route.middleware)
     )
-      
+
     # Add descriptor to express application for other middlewares
     app.descriptor = descriptor
    catch err
@@ -229,18 +232,18 @@ module.exports = (app, descriptor, resources, options = {}) ->
         resource = _.find(descriptor.apis, (res) -> return match[1] is res.resourcePath)
         unless resource?
           return res.send(404)
-        
+
         result.resourcePath = resource.resourcePath
         result.apis = resource.apis
         result.models = resource.models
        else
         # just the root
-        result.apis = _.map(result.apis, (api) -> 
+        result.apis = _.map(result.apis, (api) ->
           return {
             path: options.descPath+api.resourcePath
             description: api.description
           })
-      
+
       return res.json(result)
-    
+
     next()

--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -205,6 +205,16 @@ module.exports = (app, descriptor, resources, options = {}) ->
 
   descRoute = new RegExp("#{options.descPath}(/.*)?")
 
+  # check mandatory descriptors
+  unless descriptor.swaggerVersion
+    descriptor.swaggerVersion = '1.1'
+
+  unless descriptor.basePath
+    throw new Error('basePath is mandatory')
+
+  unless descriptor.apiVersion
+    throw new Error('apiVersion is mandatory')
+
   try
     # enrich the descriptor with apis
     routes = addRoutes(descriptor, resources)

--- a/src/validator.coffee
+++ b/src/validator.coffee
@@ -32,7 +32,7 @@ convertType = (swaggerType, parameter, allowMultiple, models) ->
   type = null
   if allowMultiple
     type = 'array';
-  else 
+  else
     switch lowerType
       when 'int', 'long', 'integer' then type = 'integer'
       when 'float', 'double', 'number' then type = 'number'
@@ -100,11 +100,11 @@ convertModel = (models, model, _stack) ->
     else
       # convert primitive type
       prop.type = convertType(prop.type, null, false, models)
-  
+
   return result
 
 # Parse the descriptor to extract an associative array with known api routes (Express path used as key).
-# For a given route, an associative array of known methods (upper case Http method names as key) contains 
+# For a given route, an associative array of known methods (upper case Http method names as key) contains
 # the expected parameters and body (for PUT and POST methods), as an array of parameterSpec.
 # The descriptor content is supposed to have been previously validated by the generator middleware
 #
@@ -133,13 +133,13 @@ analyzeRoutes = (descriptor) ->
 
           if spec.name?
             schema.title = spec.name;
-          
+
           if spec.description?
             schema.description = spec.description;
-          
+
           if schema.type is 'object'
             _.extend(schema, convertModel(descriptor.models, if spec.properties then spec else descriptor.models[spec.dataType]))
-          
+
           # manager possible values interval
           if spec.allowableValues?.valueType?
             switch spec.allowableValues.valueType.toLowerCase()
@@ -186,7 +186,7 @@ validate = (req, path, specs, next) ->
       value = null
       errPrefix = null
 
-      switch spec.kind 
+      switch spec.kind
         when 'query'
           value = req.query[spec.name]
           errPrefix = "query parameter #{spec.name}"
@@ -194,7 +194,7 @@ validate = (req, path, specs, next) ->
           value = req.headers[spec.name]
           errPrefix = "header #{spec.name}"
         when 'path'
-          # extract the parameter value: 
+          # extract the parameter value:
           match = req.path.match(regex)
           value = match[pathParamsNames[spec.name]]
           if value
@@ -252,7 +252,7 @@ validate = (req, path, specs, next) ->
               req.body = value
         done(err)
       )
-    
+
     , (err) ->
       # if an error is found, use the 400 Http code (BAD_REQUEST)
       err?.status = 400
@@ -274,8 +274,8 @@ validate = (req, path, specs, next) ->
   return req.on('end', process)
 
 # Validator function.
-# Analyze the API descriptor to extract awaited parameters and bodiy
-# When the corresponding Api is executed, validates the incoming request against the expected parameters and body, 
+# Analyze the API descriptor to extract awaited parameters and body
+# When the corresponding Api is executed, validates the incoming request against the expected parameters and body,
 # and trigger comprehensive errors
 #
 # @param app [Object] the enriched Express application.

--- a/test/apiGeneration.coffee
+++ b/test/apiGeneration.coffee
@@ -30,12 +30,18 @@ describe 'API generation tests', ->
 
   it 'should fail if no api or controller provided for a resource', ->
     assert.throws ->
-      swagger.generator express(), {}, [{}]
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [{}]
     , /Resource must contain 'api' attribute/
 
   it 'should fail on missing resource path', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api: {}
         controller: require './fixtures/sourceCrud'
       ]
@@ -43,7 +49,10 @@ describe 'API generation tests', ->
 
   it 'should fail on missing api path', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [{}]
@@ -53,7 +62,10 @@ describe 'API generation tests', ->
 
   it 'should fail on model without id', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [path: '/test/1'],
@@ -64,7 +76,10 @@ describe 'API generation tests', ->
 
   it 'should fail on model with invalid id', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [path: '/test/1'],
@@ -75,7 +90,10 @@ describe 'API generation tests', ->
 
   it 'should fail on model without properties', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [path: '/test/1'],
@@ -85,7 +103,10 @@ describe 'API generation tests', ->
     , /Response1 does not declares properties/
 
   it 'should not fail on model with properties', ->
-    swagger.generator express(), {}, [
+    swagger.generator express(),
+      apiVersion: '1.0'
+      basePath: root
+    , [
       api:
         resourcePath: '/test'
         apis: [path: '/test/1'],
@@ -97,7 +118,10 @@ describe 'API generation tests', ->
     ]
 
   it 'should not fail on model with additionalProperties', ->
-    swagger.generator express(), {}, [
+    swagger.generator express(),
+      apiVersion: '1.0'
+      basePath: root
+    , [
       api:
         resourcePath: '/test'
         apis: [path: '/test/1'],
@@ -109,7 +133,10 @@ describe 'API generation tests', ->
     ]
 
   it 'should not fail on model with items', ->
-    swagger.generator express(), {}, [
+    swagger.generator express(),
+      apiVersion: '1.0'
+      basePath: root
+    , [
       api:
         resourcePath: '/test'
         apis: [path: '/test/1'],
@@ -122,7 +149,10 @@ describe 'API generation tests', ->
 
   it 'should fail on model already defined', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [path: '/test/1'],
@@ -149,7 +179,10 @@ describe 'API generation tests', ->
 
   it 'should fail on unsupported operation in descriptor', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -165,7 +198,10 @@ describe 'API generation tests', ->
 
   it 'should fail on unsupported operation in descriptor', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -179,9 +215,48 @@ describe 'API generation tests', ->
       ]
     , /operation TOTO is not supported/
 
+  it 'should fail on missing basePath', ->
+    assert.throws ->
+      swagger.generator express(),
+        apiVersion: '1.0'
+      , [
+        api:
+          resourcePath: '/test'
+          apis: [
+            path: '/'
+            operations: [
+              httpMethod: 'GET'
+              nickname: 'doNotExist'
+            ]
+          ]
+        controller: require './fixtures/sourceCrud'
+      ]
+    , /basePath is mandatory/
+
+  it 'should fail on missing apiVersion', ->
+    assert.throws ->
+      swagger.generator express(),
+        basePath: root
+      , [
+        api:
+          resourcePath: '/test'
+          apis: [
+            path: '/'
+            operations: [
+              httpMethod: 'GET'
+              nickname: 'doNotExist'
+            ]
+          ]
+        controller: require './fixtures/sourceCrud'
+      ]
+    , /apiVersion is mandatory/
+
   it 'should fail on missing responseClass', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -197,7 +272,10 @@ describe 'API generation tests', ->
 
   it 'should fail on missing nickname in descriptor', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -213,7 +291,10 @@ describe 'API generation tests', ->
 
   it 'should fail on duplicate parameters in descriptor', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -243,7 +324,10 @@ describe 'API generation tests', ->
 
   it 'should fail on parameter (not body) without name', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -263,7 +347,10 @@ describe 'API generation tests', ->
 
   it 'should fail on parameter without paramType', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -283,7 +370,10 @@ describe 'API generation tests', ->
 
   it 'should fail on unknown type parameter', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -304,7 +394,10 @@ describe 'API generation tests', ->
 
   it 'should fail on optionnal path parameter', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -326,7 +419,10 @@ describe 'API generation tests', ->
 
   it 'should fail on path parameter with multiple values', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -348,7 +444,10 @@ describe 'API generation tests', ->
 
   it 'should fail on path parameter disclosure between path and parameter array', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -369,7 +468,10 @@ describe 'API generation tests', ->
 
   it 'should fail on path parameter name disclosure between path and parameter array', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -393,7 +495,10 @@ describe 'API generation tests', ->
 
   it 'should fail on two anonymous body parameters', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -415,7 +520,10 @@ describe 'API generation tests', ->
 
   it 'should fail on body parameters for other than put and post', ->
     assert.throws ->
-      swagger.generator express(), {}, [
+      swagger.generator express(),
+        apiVersion: '1.0'
+        basePath: root
+      , [
         api:
           resourcePath: '/test'
           apis: [
@@ -433,6 +541,39 @@ describe 'API generation tests', ->
       ]
     , /operation DELETE does not allowed body parameters/
 
+  it 'should preserve swaggerVersion', (done) ->
+    # given a server with api and custom descriptor path
+    app = express()
+    app.use(express.cookieParser())
+      .use(express.methodOverride())
+      .use(express.bodyParser())
+      .use(swagger.generator(app,
+        swaggerVersion: '1.0'
+        apiVersion: '1.0'
+        basePath: root
+      , []))
+    server = http.createServer app
+    server.listen port, host, _.defer((err) ->
+      return done err if err?
+      # when requesting the API description details
+      request.get(
+        url: 'http://'+host+':'+port+'/api-docs.json'
+        json: true
+      , (err, res, body) ->
+        return done err if err?
+        # then a json file is returned
+        assert.equal res.statusCode, 200
+        assert.deepEqual body,
+          apiVersion: '1.0'
+          basePath: '/api'
+          swaggerVersion: "1.0"
+          apis: []
+          models: {}
+        server.close()
+        done()
+      )
+    )
+
   it 'should customize the generated descriptor path', (done) ->
     # given a server with api and custom descriptor path
     app = express()
@@ -440,7 +581,7 @@ describe 'API generation tests', ->
       .use(express.methodOverride())
       .use(express.bodyParser())
       .use(swagger.generator(app,
-        apiVersion: '1.0',
+        apiVersion: '1.0'
         basePath: root
       , [
         api: require './fixtures/streamApi.yml'
@@ -460,6 +601,7 @@ describe 'API generation tests', ->
         assert.deepEqual body,
           apiVersion: '1.0'
           basePath: '/api'
+          swaggerVersion: "1.1"
           apis: [
             path: '/my-desc/stream'
           ]
@@ -476,7 +618,7 @@ describe 'API generation tests', ->
       .use(express.methodOverride())
       .use(express.bodyParser())
       .use(swagger.generator(app,
-        apiVersion: '1.0',
+        apiVersion: '1.0'
         basePath: root
       , [
         api: require './fixtures/streamApi.yml'
@@ -496,6 +638,7 @@ describe 'API generation tests', ->
         # then a json file is returned
         assert.equal res.statusCode, 200
         assert.deepEqual body,
+          swaggerVersion: "1.1"
           apiVersion: '1.0'
           basePath: '/api'
           apis: [
@@ -511,6 +654,7 @@ describe 'API generation tests', ->
         , (err, res, body) ->
           return done err if err?
           assert.deepEqual body,
+            swaggerVersion: "1.1"
             apiVersion: '1.0'
             basePath: '/api'
             apis: [
@@ -538,7 +682,7 @@ describe 'API generation tests', ->
         .use(express.methodOverride())
         .use(express.bodyParser())
         .use(swagger.generator(app,
-          apiVersion: '1.0',
+          apiVersion: '1.0'
           basePath: root
         , [{
           api: require './fixtures/addressApi.yml'
@@ -566,6 +710,7 @@ describe 'API generation tests', ->
         # then a json file is returned
         assert.equal res.statusCode, 200
         assert.deepEqual body,
+          swaggerVersion: "1.1"
           apiVersion: '1.0'
           basePath: '/api'
           resourcePath: '/address'
@@ -612,7 +757,7 @@ describe 'API generation tests', ->
           .use(express.methodOverride())
           .use(express.bodyParser())
           .use(swagger.generator(app,
-            apiVersion: '1.0',
+            apiVersion: '1.0'
             basePath: root
           , [
             api: require './fixtures/sourceApi.yml'
@@ -701,8 +846,9 @@ describe 'API generation tests', ->
         # then a json file is returned
         assert.equal res.statusCode, 200
         assert.deepEqual body,
-          apiVersion: '1.0',
-          basePath: '/api',
+          swaggerVersion: "1.1"
+          apiVersion: '1.0'
+          basePath: '/api'
           apis: [
             path:"/api-docs.json/source"
           ,
@@ -719,6 +865,7 @@ describe 'API generation tests', ->
           # then a json file is returned
           assert.equal res.statusCode, 200
           assert.deepEqual body,
+            swaggerVersion: "1.1"
             apiVersion: '1.0'
             basePath: '/api'
             resourcePath: '/source'

--- a/test/apiGeneration.coffee
+++ b/test/apiGeneration.coffee
@@ -126,22 +126,22 @@ describe 'API generation tests', ->
         api:
           resourcePath: '/test'
           apis: [path: '/test/1'],
-          models: 
-            Response2: 
+          models:
+            Response2:
               id: 'Response2'
-              properties: 
-                name: 
+              properties:
+                name:
                   type: 'String'
         controller: require './fixtures/sourceCrud'
       ,
         api:
           resourcePath: '/test2'
           apis: [path: '/test2/1'],
-          models: 
-            Response2: 
-              id: 'Response2' 
-              properties: 
-                name: 
+          models:
+            Response2:
+              id: 'Response2'
+              properties:
+                name:
                   type: 'String'
         controller: require './fixtures/sourceCrud'
       ]
@@ -163,7 +163,23 @@ describe 'API generation tests', ->
       ]
     , /operation TOTO is not supported/
 
-  it 'should fail on unknown nickname in descriptor', ->
+  it 'should fail on unsupported operation in descriptor', ->
+    assert.throws ->
+      swagger.generator express(), {}, [
+        api:
+          resourcePath: '/test'
+          apis: [
+            path: '/'
+            operations: [
+              httpMethod: 'TOTO'
+              nickname: 'doNotExist'
+            ]
+          ]
+        controller: require './fixtures/sourceCrud'
+      ]
+    , /operation TOTO is not supported/
+
+  it 'should fail on missing responseClass', ->
     assert.throws ->
       swagger.generator express(), {}, [
         api:
@@ -177,7 +193,7 @@ describe 'API generation tests', ->
           ]
         controller: require './fixtures/sourceCrud'
       ]
-    , /nickname doNotExist cannot be found in controller/
+    , /responseClass is mandatory. If no result expected, responseClass should be void/
 
   it 'should fail on missing nickname in descriptor', ->
     assert.throws ->
@@ -186,6 +202,7 @@ describe 'API generation tests', ->
           resourcePath: '/test'
           apis: [
             path: '/'
+            responseClass: 'void'
             operations: [
               httpMethod: 'GET'
             ]
@@ -203,6 +220,7 @@ describe 'API generation tests', ->
             path: '/'
             operations: [
               httpMethod: 'GET'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 name: 'p1'
@@ -232,6 +250,7 @@ describe 'API generation tests', ->
             path: '/'
             operations: [
               httpMethod: 'GET'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 paramType: 'query'
@@ -251,6 +270,7 @@ describe 'API generation tests', ->
             path: '/'
             operations: [
               httpMethod: 'GET'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 name: 'p1'
@@ -270,6 +290,7 @@ describe 'API generation tests', ->
             path: '/'
             operations: [
               httpMethod: 'GET'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 name: 'p1'
@@ -290,6 +311,7 @@ describe 'API generation tests', ->
             path: '/{p1}'
             operations: [
               httpMethod: 'GET'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 name: 'p1'
@@ -311,6 +333,7 @@ describe 'API generation tests', ->
             path: '/{p1}'
             operations: [
               httpMethod: 'GET'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 name: 'p1'
@@ -332,6 +355,7 @@ describe 'API generation tests', ->
             path: '/{p1}/{p2}/{p3}'
             operations: [
               httpMethod: 'GET'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 name: 'p1'
@@ -352,6 +376,7 @@ describe 'API generation tests', ->
             path: '/{p1}/{p2}'
             operations: [
               httpMethod: 'GET'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 name: 'p1'
@@ -375,6 +400,7 @@ describe 'API generation tests', ->
             path: '/test'
             operations: [
               httpMethod: 'POST'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 paramType: 'body'
@@ -396,6 +422,7 @@ describe 'API generation tests', ->
             path: '/test'
             operations: [
               httpMethod: 'DELETE'
+              responseClass: 'void'
               nickname: 'stat'
               parameters: [
                 paramType: 'body'
@@ -412,7 +439,7 @@ describe 'API generation tests', ->
     app.use(express.cookieParser())
       .use(express.methodOverride())
       .use(express.bodyParser())
-      .use(swagger.generator(app, 
+      .use(swagger.generator(app,
         apiVersion: '1.0',
         basePath: root
       , [
@@ -430,13 +457,13 @@ describe 'API generation tests', ->
         return done err if err?
         # then a json file is returned
         assert.equal res.statusCode, 200
-        assert.deepEqual body, 
+        assert.deepEqual body,
           apiVersion: '1.0'
           basePath: '/api'
           apis: [
             path: '/my-desc/stream'
           ]
-          models: {} 
+          models: {}
         server.close()
         done()
       )
@@ -448,7 +475,7 @@ describe 'API generation tests', ->
     app.use(express.cookieParser())
       .use(express.methodOverride())
       .use(express.bodyParser())
-      .use(swagger.generator(app, 
+      .use(swagger.generator(app,
         apiVersion: '1.0',
         basePath: root
       , [
@@ -468,7 +495,7 @@ describe 'API generation tests', ->
         return done err if err?
         # then a json file is returned
         assert.equal res.statusCode, 200
-        assert.deepEqual body, 
+        assert.deepEqual body,
           apiVersion: '1.0'
           basePath: '/api'
           apis: [
@@ -476,8 +503,8 @@ describe 'API generation tests', ->
           ,
             path: '/api-docs.json/source'
           ]
-          models: {} 
-        # then the unwired resource details are available 
+          models: {}
+        # then the unwired resource details are available
         request.get(
           url: 'http://'+host+':'+port+'/api-docs.json/source'
           json: true
@@ -486,10 +513,11 @@ describe 'API generation tests', ->
           assert.deepEqual body,
             apiVersion: '1.0'
             basePath: '/api'
-            apis: [ 
+            apis: [
               path: '/source/stats'
               operations: [
                 httpMethod: 'GET'
+                responseClass: 'void'
               ]
             ],
             models: {},
@@ -509,7 +537,7 @@ describe 'API generation tests', ->
       app.use(express.cookieParser())
         .use(express.methodOverride())
         .use(express.bodyParser())
-        .use(swagger.generator(app, 
+        .use(swagger.generator(app,
           apiVersion: '1.0',
           basePath: root
         , [{
@@ -545,6 +573,7 @@ describe 'API generation tests', ->
             path: '/address'
             operations: [
               httpMethod: 'POST'
+              responseClass: 'Address'
               nickname: 'passed'
               parameters: [
                 dataType: 'Address'
@@ -553,7 +582,7 @@ describe 'API generation tests', ->
               ]
             ]
           ],
-          models: 
+          models:
             Address:
               id: 'Address'
               properties:
@@ -582,7 +611,7 @@ describe 'API generation tests', ->
         app.use(express.cookieParser())
           .use(express.methodOverride())
           .use(express.bodyParser())
-          .use(swagger.generator(app, 
+          .use(swagger.generator(app,
             apiVersion: '1.0',
             basePath: root
           , [
@@ -697,21 +726,26 @@ describe 'API generation tests', ->
               path: '/source'
               operations: [
                 httpMethod: 'GET'
+                responseClass: 'void'
                 nickname: 'list'
               ,
                 httpMethod: 'POST'
+                responseClass: 'void'
                 nickname: 'create'
               ]
             ,
               path: '/source/{id}'
               operations: [
                 httpMethod: 'GET'
+                responseClass: 'void'
                 nickname: 'getById'
               ,
                 httpMethod: 'PUT'
+                responseClass: 'void'
                 nickname: 'update'
               ,
                 httpMethod: 'DELETE'
+                responseClass: 'void'
                 nickname: 'remove'
               ]
             ]

--- a/test/apiValidation.coffee
+++ b/test/apiValidation.coffee
@@ -64,11 +64,11 @@ multipartApi = (name, formdata, parts, status, expectedBody, done) ->
     multipart: []
     encoding: 'utf8'
   if formdata
-    req.headers = 
+    req.headers =
       'content-type': 'multipart/form-data'
   for part in parts
-    obj = 
-      body: part.body 
+    obj =
+      body: part.body
     obj['content-disposition'] = "form-data; name=\"#{part.name}\"" if part.name?
     req.multipart.push obj
 
@@ -101,7 +101,10 @@ describe 'API validation tests', ->
       # configured to use swagger generator
       app.use(express.bodyParser())
         .use(express.methodOverride())
-        .use(swagger.generator app, {}, [
+        .use(swagger.generator app,
+          apiVersion: '1.0'
+          basePath: root
+        , [
           api: require './fixtures/circular.yml'
           controller: returnBody: (req, res) -> res.json body:req.body
         ])
@@ -117,7 +120,10 @@ describe 'API validation tests', ->
       # configured to use swagger generator
       app.use(express.bodyParser())
         .use(express.methodOverride())
-        .use(swagger.generator app, {}, [
+        .use(swagger.generator app,
+          apiVersion: '1.0'
+          basePath: root
+        , [
           api: require './fixtures/validatedApi.yml'
           controller:
             passed: (req, res) -> res.json status: 'passed'
@@ -184,7 +190,7 @@ describe 'API validation tests', ->
             city: 'lyon'
             street: 'bd vivier merles'
             zipcode: 69006
-          ] 
+          ]
         getApi 'complexqueryparam', {user:JSON.stringify obj}, {}, 200, {user:obj}, done
 
     describe 'given an api accepting header parameters', ->
@@ -197,7 +203,7 @@ describe 'API validation tests', ->
         getApi 'headerparams', null, headers, 200, headers, done
 
       it 'should long and boolean be parsed', (done) ->
-        headers = 
+        headers =
           param1: -2
           param2: false
         getApi 'headerparams', null, headers, 200, headers, done
@@ -228,7 +234,7 @@ describe 'API validation tests', ->
             city: 'lyon'
             street: 'bd vivier merles'
             zipcode: 69006
-          ] 
+          ]
         getApi 'complexheaderparam', null, {user:JSON.stringify obj}, 200, {user:obj}, done
 
     describe 'given an api accepting path parameters', ->
@@ -274,19 +280,19 @@ describe 'API validation tests', ->
       it 'should multi-part/related body not be parsed', (done) ->
         multipartApi 'multiplebody', false, [
             name: 'param1'
-            body: '-5' 
+            body: '-5'
           ,
             name: 'param2'
-            body: 'false,true' 
+            body: 'false,true'
           ], 400, {message: 'body parameter param1 is required'}, done
 
       it 'should multi-part/form-data body be parsed and casted down', (done) ->
         multipartApi 'multiplebody', true, [
             name: 'param1'
-            body: '-5' 
+            body: '-5'
           ,
             name: 'param2'
-            body: 'false,true' 
+            body: 'false,true'
           ], 200, {body:{param1: -5, param2: [false, true]}}, done
 
       it 'should multi-part body parameter be optionnal', (done) ->
@@ -300,7 +306,7 @@ describe 'API validation tests', ->
             city: 'lyon'
             street: 'bd vivier merle'
             zipcode: 69006
-          ] 
+          ]
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 200, {body:obj}, done
 
       it 'should multiple anonymous optionnal body accept one value', (done) ->
@@ -337,7 +343,7 @@ describe 'API validation tests', ->
           id: 11
           firstName: 'jean'
           lastName: 'dupond'
-          addresses: [] 
+          addresses: []
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 400, {message: "body property 'firstName' is not explicitly defined and therefore not allowed"}, done
 
       it 'should complex json body refs be checked', (done) ->
@@ -347,7 +353,7 @@ describe 'API validation tests', ->
           addresses: [
             ville: 'lyon',
             street: 'bd vivier merle'
-          ] 
+          ]
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 400, {message: "body property 'addresses.[0].ville' is not explicitly defined and therefore not allowed"}, done
 
       it 'should range list value be checked', (done) ->
@@ -358,7 +364,7 @@ describe 'API validation tests', ->
             city: 'strasbourd'
             zipcode: 67000
             street: 'bd vivier merle'
-          ] 
+          ]
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 400, {message: "body property 'addresses.[0].city' is not in enum"}, done
 
       it 'should range interval value be checked', (done) ->
@@ -369,7 +375,7 @@ describe 'API validation tests', ->
             city: 'lyon'
             zipcode: 100000
             street: 'bd vivier merle'
-          ] 
+          ]
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 400, {message: "body property 'addresses.[0].zipcode' is 100000 when it should be at most 99999"}, done
 
       it 'should required attributes be checked', (done) ->
@@ -379,7 +385,7 @@ describe 'API validation tests', ->
             city: 'lyon'
             zipcode: 69003
             street: 'bd vivier merle'
-          ] 
+          ]
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 400, {message: "body property 'id' is required"}, done
 
       it 'should primitive values be parsed', (done) ->
@@ -390,7 +396,7 @@ describe 'API validation tests', ->
             city: 'lyon'
             zipcode: 69003
             street: 'bd vivier merle'
-          ] 
+          ]
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 400, {message: "body property 'id' is a boolean when it should be an integer"}, done
 
       it 'should additionnal attribute not be allowed', (done) ->
@@ -402,7 +408,7 @@ describe 'API validation tests', ->
             zipcode: 69003
             street: 'bd vivier merle'
             other: 'coucou'
-          ] 
+          ]
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 400, {message: "body property 'addresses.[0].other' is not explicitly defined and therefore not allowed"}, done
 
       it 'should optionnal attribute be allowed', (done) ->
@@ -421,7 +427,7 @@ describe 'API validation tests', ->
             zipcode: 69003
             street: 'bd vivier merle'
             other: 'coucou'
-          ] 
+          ]
         postApi 'complexbody', {'Content-Type': 'application/json'}, JSON.stringify(obj), 400, {message: "body property 'stuff.name' is an integer when it should be a string"}, done
 
       it 'should classical json-schema specification be usabled', (done) ->
@@ -458,7 +464,7 @@ describe 'API validation tests', ->
       it 'should reject when passing file not in multipart', (done) ->
 
         file = pathUtils.join __dirname, 'fixtures/circular.yml'
-        postApi 'upload', {'Content-Type': 'application/json'}, JSON.stringify(file:file.toString()), 400, 
+        postApi 'upload', {'Content-Type': 'application/json'}, JSON.stringify(file:file.toString()), 400,
           {message: "body parameter file is required"}, done
 
       it 'should fail on missing body file', (done) ->

--- a/test/fixtures/addressApi.yml
+++ b/test/fixtures/addressApi.yml
@@ -6,6 +6,7 @@ apis:
 
   - httpMethod: POST
     nickname: passed
+    responseClass: Address
     parameters:
 
     - dataType: Address

--- a/test/fixtures/circular.yml
+++ b/test/fixtures/circular.yml
@@ -6,6 +6,7 @@ apis:
 
   - httpMethod: POST
     nickname: returnBody
+    responseClass: void
     parameters:
 
     - name: user

--- a/test/fixtures/notwired.yml
+++ b/test/fixtures/notwired.yml
@@ -3,3 +3,4 @@ apis:
 - path: /source/stats
   operations:
   - httpMethod: GET
+    responseClass: void

--- a/test/fixtures/sourceApi.yml
+++ b/test/fixtures/sourceApi.yml
@@ -3,18 +3,23 @@ apis:
 - path: /source
   operations:
   - httpMethod: GET
+    responseClass: void
     nickname: list
 
   - httpMethod: POST
+    responseClass: void
     nickname: create
 
 - path: /source/{id}
   operations:
   - httpMethod: GET
+    responseClass: void
     nickname: getById
 
   - httpMethod: PUT
+    responseClass: void
     nickname: update
 
   - httpMethod: DELETE
+    responseClass: void
     nickname: remove

--- a/test/fixtures/streamApi.yml
+++ b/test/fixtures/streamApi.yml
@@ -4,3 +4,4 @@ apis:
   operations:
   - httpMethod: GET
     nickname: stat
+    responseClass: void

--- a/test/fixtures/validatedApi.yml
+++ b/test/fixtures/validatedApi.yml
@@ -4,11 +4,13 @@ apis:
 - path: /api/noparams/{id}
   operations:
   - httpMethod: GET
+    responseClass: void
     nickname: passed
 
 - path: /api/pathparams/{param1}/{param2}
   operations:
   - httpMethod: GET
+    responseClass: void
     nickname: returnParams
     parameters:
 
@@ -23,6 +25,7 @@ apis:
 - path: /api/queryparams
   operations:
   - httpMethod: GET
+    responseClass: void
     nickname: returnParams
     parameters:
 
@@ -43,6 +46,7 @@ apis:
 - path: /api/headerparams
   operations:
   - httpMethod: GET
+    responseClass: void
     nickname: returnParams
     parameters:
 
@@ -64,6 +68,7 @@ apis:
   operations:
 
   - httpMethod: POST
+    responseClass: void
     nickname: returnBody
     parameters:
 
@@ -75,6 +80,7 @@ apis:
   operations:
 
   - httpMethod: POST
+    responseClass: void
     nickname: returnBody
     parameters:
 
@@ -85,6 +91,7 @@ apis:
   operations:
 
   - httpMethod: POST
+    responseClass: void
     nickname: returnBody
     parameters:
 
@@ -103,6 +110,7 @@ apis:
   operations:
 
   - httpMethod: POST
+    responseClass: void
     nickname: returnBody
     parameters:
 
@@ -115,6 +123,7 @@ apis:
   operations:
 
   - httpMethod: POST
+    responseClass: void
     nickname: returnBody
     parameters:
 
@@ -126,6 +135,7 @@ apis:
   operations:
 
   - httpMethod: POST
+    responseClass: void
     nickname: returnBody
     parameters:
 
@@ -138,6 +148,7 @@ apis:
   operations:
 
   - httpMethod: GET
+    responseClass: void
     nickname: returnParams
     parameters:
 
@@ -150,6 +161,7 @@ apis:
   operations:
 
   - httpMethod: GET
+    responseClass: void
     nickname: returnParams
     parameters:
 
@@ -162,6 +174,7 @@ apis:
   operations:
 
     - httpMethod: POST
+      responseClass: void
       nickname: returnBody
       parameters:
 
@@ -173,6 +186,7 @@ apis:
   operations:
 
     - httpMethod: POST
+      responseClass: void
       nickname: returnBody
       parameters:
 
@@ -184,6 +198,7 @@ apis:
   operations:
 
     - httpMethod: POST
+      responseClass: void
       nickname: passed
       parameters:
       - name: file


### PR DESCRIPTION
Swagger defines responseClass, basePath, apiVersion, swaggerVersion as mandatory so the generator should check if it's correctly setted.

Swagger also defines that the responseClass should be "void" when no response expected, so, generator should accept this value.

As this pullrequest breaks backward compatibility, the version goes from 1.4.2 to 1.5.0.
