### PR TITLE
api-docs.json incorrectly prefixed apis path

### DIFF
--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -255,8 +255,9 @@ module.exports = (app, descriptor, resources, options = {}) ->
        else
         # just the root
         result.apis = _.map(result.apis, (api) ->
+          descPrefix = options.descPath.replace(new RegExp("^#{prefix}"), '');
           return {
-            path: options.descPath+api.resourcePath
+            path: descPrefix+api.resourcePath
             description: api.description
           })
 


### PR DESCRIPTION
Looking at the petstore example, the api-docs.json is as follow:

http://petstore.swagger.wordnik.com/api/api-docs.json

``` javascript
{
        apiVersion: "0.2",
        swaggerVersion: "1.1",
        basePath: "http://petstore.swagger.wordnik.com/api",
        apis:  [
         {
        path: "/api-docs.{format}/user",
        description: ""
        },
         {
        path: "/api-docs.{format}/pet",
        description: ""
        }
        ]
}
```

where as swagger-jack generated api-docs.json is:

``` javascript
{
        apiVersion: "2.0",
        swaggerVersion: "1.1",
        basePath: "http://local.host:3000/api",
        apis:  [
         {
        path: "/api/api-docs.json/users"
        },
               {
        path: "/api/api-docs.json/orgs"
        },
         {
        path: "/api/api-docs.json/projects"
        }
        ]
}
```

The extra leading "/api" at apis[0].path breaks swagger-ui which prepends basePath to apis.path for fetching api specs.
