### PR TITLE
wildcard parameter is extracted properly

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -58,7 +58,7 @@ module.exports = {
     # create a regular expression to extract path parameters and isolate their names
     regex = new RegExp(path.replace(/:([^\/]+)/g, (match, key) ->
       pathParamsNames[key] = ++i
-      return '([^\/]*)'
+      return if key.match(/\*$/) then '(.*)' else '([^\/]*)'
     ))
     [regex, pathParamsNames]
 

--- a/test/apiValidation.coffee
+++ b/test/apiValidation.coffee
@@ -410,6 +410,9 @@ describe 'API validation tests', ->
       it 'should int and boolean be parsed', (done) ->
         getApi 'api/pathparams/10/true', null, {}, 200, {param1:10, param2:true}, done
 
+      it 'should take wildcard path param', (done) ->
+        getApi 'api/pathparams/10/foo/bar/suffix', null, {}, 200, {param1:'10', 'param2*':'foo/bar'}, done
+
     describe 'given an api accepting body parameters', ->
 
       it 'should plain text body be parsed', (done) ->

--- a/test/fixtures/validatedApi.yml
+++ b/test/fixtures/validatedApi.yml
@@ -22,6 +22,21 @@ apis:
       dataType: boolean
       paramType: path
 
+- path: /api/pathparams/{param1}/{param2*}/suffix
+  operations:
+    - httpMethod: GET
+      responseClass: void
+      nickname: returnParams
+      parameters:
+
+        - name: param1
+          dataType: string
+          paramType: path
+
+        - name: param2*
+          dataType: string
+          paramType: path
+
 - path: /api/queryparams
   operations:
   - httpMethod: GET


### PR DESCRIPTION
If path is `<basePath>/{url*}/foobar`, regex generated is `<basePath>/[^/]*/foobar`  when it should be `<basePath>/.*/foobar`  due to wildcard.
